### PR TITLE
Fixing "ImportError: No module named PIL"

### DIFF
--- a/install.py
+++ b/install.py
@@ -45,7 +45,7 @@ def main():
 	system0 = raw_input(">>> ")
 	if system0 == "1":
 		print("\033[1;34m\n[++] Installing Xerosploit ... \033[1;m")
-		install = os.system("apt-get update && apt-get install -y nmap hping3 build-essential python-pip ruby-dev git libpcap-dev libgmp3-dev && pip install tabulate terminaltables")
+		install = os.system("apt-get update && apt-get install -y nmap hping3 build-essential python-pip ruby-dev git libpcap-dev libgmp3-dev && pip install tabulate terminaltables Pillow")
 
 		install1 = os.system("""cd tools/bettercap/ && gem build bettercap.* && sudo gem install xettercap-* && rm xettercap-* && cd ../../ && mkdir -p /opt/xerosploit && cp -R tools/ /opt/xerosploit/ && cp xerosploit.py /opt/xerosploit/xerosploit.py && cp banner.py /opt/xerosploit/banner.py && cp run.sh /usr/bin/xerosploit && chmod +x /usr/bin/xerosploit && tput setaf 34; echo "Xerosploit has been sucessfuly instaled. Execute 'xerosploit' in your terminal." """)	
 	elif system0 == "2":


### PR DESCRIPTION
>  File "/opt/xerosploit/xerosploit.py", line 621, in replace
>     from PIL import Image
> ImportError: No module named PIL 

The use of PIL is deprecated, with Pillow installation this error will be fixed.