### PR TITLE
terminaltables error again

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Dependencies will be automatically installed.
     Add this:
     deb http://deb.debian.org/debian/ buster main
     
-    git clone https://github.com/LionSec/xerosploit
+    git clone https://github.com/FazalMahmood/xerosploit/
     cd xerosploit && sudo python install.py
     sudo xerosploit
     

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build](https://img.shields.io/badge/Supported_OS-linux-orange.svg)]()
 [![AUR](https://img.shields.io/aur/license/yaourt.svg)]()
 
-Xerosploit
+Xerosploit (This is a Fork to fix Terminaltables Error and other Installation Issues on Latest Operating Systems)
 =
 Xerosploit is a penetration testing toolkit whose goal is to perform man in the middle attacks for testing purposes. It brings various modules that allow to realise efficient attacks, and also allows to carry out denial of service attacks and port scanning.
 Powered by <a href="https://www.bettercap.org"> bettercap</a> and <a href="https://www.bettercap.org"> nmap</a>.
@@ -45,30 +45,30 @@ Dependencies will be automatically installed.
     
 Manual Instalation (If in any case above mathod does't work for you, try following steps):
 =   
-Add Debian Repository:
-$ sudo nano /etc/apt/sources.list
+    Add Debian Repository:
+    $ sudo nano /etc/apt/sources.list
 
-Add following link to "sources.list" file:
-deb http://deb.debian.org/debian/ buster main
+    Add following link to "sources.list" file:
+    deb http://deb.debian.org/debian/ buster main
 
-Install Dependencies:
-$ sudo apt update && sudo apt install python-pip-whl=18.1-5 python-all-dev  python-setuptools python-wheel python-pip
+    Install Dependencies:
+    $ sudo apt update && sudo apt install python-pip-whl=18.1-5 python-all-dev  python-setuptools python-wheel python-pip
 
-Download and Run Official Packages:
-$ git clone https://github.com/LionSec/xerosploit
-$ cd xerosploit && sudo python install.py
-$ sudo apt install python3-terminaltables
-$ sudo xerosploit
+    Download and Run Official Packages:
+    $ git clone https://github.com/LionSec/xerosploit
+    $ cd xerosploit && sudo python install.py
+    $ sudo apt install python3-terminaltables
+    $ sudo xerosploit
 
 
-**Issues:**
-Real-time Sniffing logs doesn't work out of the box, you need to run this command each time to monitor real-time logs:
+    **Issues:**
+    Real-time Sniffing logs doesn't work out of the box, you need to run this command each time to monitor real-time logs:
 
-**See Logs File:**
-$ ls /opt/xerosploit/xerosniff
+    **See Logs File:**
+    $ ls /opt/xerosploit/xerosniff
 
-**Monitor Logs in Real-Time: (change file name to your log file)**
-$ sudo tail -f /opt/xerosploit/xerosniff/LOG_FILE.log
+    **Monitor Logs in Real-Time: (change file name to your log file)**
+    $ sudo tail -f /opt/xerosploit/xerosniff/LOG_FILE.log
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Instalation
 =
 Dependencies will be automatically installed.
 
+    Add Debian Repository:
+    $ sudo nano /etc/apt/sources.list
+    
+    Add this:
+    deb http://deb.debian.org/debian/ buster main
+    
     git clone https://github.com/LionSec/xerosploit
     cd xerosploit && sudo python install.py
     sudo xerosploit
@@ -40,20 +46,8 @@ Tested on
 
 <table>
     <tr>
-        <th>Operative system</th>
-        <th> Version </th>
-    </tr>
-    <tr>
-        <td>Ubuntu</td>
-        <td> 16.04  / 15.10 </td>
-    </tr>
-    <tr>
-        <td>Kali linux</td>
-        <td> Rolling / Sana</td>
-    </tr>
-    <tr>
-        <td>Parrot OS</td>
-        <td>3.1 </td>
+        <td>Kali Linux</td>
+        <td>2020.2 , 2020.3</td>
     </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,37 @@ Dependencies will be automatically installed.
     git clone https://github.com/LionSec/xerosploit
     cd xerosploit && sudo python install.py
     sudo xerosploit
+    
+    
+    
+    
+Manual Instalation (If in any case above mathod does't work for you, try following steps):
+=   
+Add Debian Repository:
+$ sudo nano /etc/apt/sources.list
+
+Add following link to "sources.list" file:
+deb http://deb.debian.org/debian/ buster main
+
+Install Dependencies:
+$ sudo apt update && sudo apt install python-pip-whl=18.1-5 python-all-dev  python-setuptools python-wheel python-pip
+
+Download and Run Official Packages:
+$ git clone https://github.com/LionSec/xerosploit
+$ cd xerosploit && sudo python install.py
+$ sudo apt install python3-terminaltables
+$ sudo xerosploit
+
+
+**Issues:**
+Real-time Sniffing logs doesn't work out of the box, you need to run this command each time to monitor real-time logs:
+
+**See Logs File:**
+$ ls /opt/xerosploit/xerosniff
+
+**Monitor Logs in Real-Time: (change file name to your log file)**
+$ sudo tail -f /opt/xerosploit/xerosniff/LOG_FILE.log
+
 
 
 Tested on
@@ -53,7 +84,7 @@ Tested on
 
 
 
-features 
+Features 
 =
 - Port scanning
 - Network mapping
@@ -77,16 +108,4 @@ I have some questions!
 
 Please visit https://github.com/LionSec/xerosploit/issues
 
-Donations
-=
-- Paypal : https://www.paypal.me/lionsec
-- Bitcoin : 12dM5kZjYMizNuXaqu7QZBLNDkXjfKYpRD
 
-
-Contact
-=
-- Website : https://neodrix.com
-- Youtube : https://youtube.com/inf98es
-- Facebook : https://facebook.com/in98
-- Twitter: @LionSec1
-- Email : informatic98es@gmail.com

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Dependencies will be automatically installed.
     
     
     
-Manual Instalation (If in any case above mathod does't work for you, try following steps):
+Manual Setup (If in any case above mathod does't work for you, try following steps):
 =   
     Add Debian Repository:
     $ sudo nano /etc/apt/sources.list
@@ -52,7 +52,7 @@ Manual Instalation (If in any case above mathod does't work for you, try followi
     deb http://deb.debian.org/debian/ buster main
 
     Install Dependencies:
-    $ sudo apt update && sudo apt install python-pip-whl=18.1-5 python-all-dev  python-setuptools python-wheel python-pip
+    $ sudo apt update && sudo apt install python-pip-whl=18.1-5 python-all-dev python-setuptools python-wheel python-pip
 
     Download and Run Official Packages:
     $ git clone https://github.com/LionSec/xerosploit
@@ -61,17 +61,17 @@ Manual Instalation (If in any case above mathod does't work for you, try followi
     $ sudo xerosploit
 
 
-    **Issues:**
+Issues:
+=
     Real-time Sniffing logs doesn't work out of the box, you need to run this command each time to monitor real-time logs:
 
-    **See Logs File:**
+    See Logs File:
     $ ls /opt/xerosploit/xerosniff
 
-    **Monitor Logs in Real-Time: (change file name to your log file)**
+    Monitor Logs in Real-Time: (change file name to your log file)
     $ sudo tail -f /opt/xerosploit/xerosniff/LOG_FILE.log
-
-
-
+    
+    
 Tested on
 =
 

--- a/install.py
+++ b/install.py
@@ -45,7 +45,7 @@ def main():
 	system0 = raw_input(">>> ")
 	if system0 == "1":
 		print("\033[1;34m\n[++] Installing Xerosploit ... \033[1;m")
-		install = os.system("apt-get update && apt-get install -y nmap hping3 build-essential python-pip ruby-dev git libpcap-dev libgmp3-dev && pip install tabulate terminaltables")
+		install = os.system("apt-get update && apt-get install -y nmap hping3 build-essential python-pip-whl=18.1-5 python-all-dev  python-setuptools python-wheel python-pip ruby-dev git libpcap-dev libgmp3-dev && pip install tabulate terminaltables")
 
 		install1 = os.system("""cd tools/bettercap/ && gem build bettercap.* && sudo gem install xettercap-* && rm xettercap-* && cd ../../ && mkdir -p /opt/xerosploit && cp -R tools/ /opt/xerosploit/ && cp xerosploit.py /opt/xerosploit/xerosploit.py && cp banner.py /opt/xerosploit/banner.py && cp run.sh /usr/bin/xerosploit && chmod +x /usr/bin/xerosploit && tput setaf 34; echo "Xerosploit has been sucessfuly instaled. Execute 'xerosploit' in your terminal." """)	
 	elif system0 == "2":

--- a/install.py
+++ b/install.py
@@ -54,7 +54,7 @@ def main():
 		bet_un = os.system("apt-get remove bettercap") # Remove bettercap to avoid some problems . Installed by default with apt-get .
 		bet_re_ins = os.system("gem install bettercap") # Reinstall bettercap with gem.
 
-		install = os.system("apt-get update && apt-get install -y nmap hping3 ruby-dev git libpcap-dev libgmp3-dev python-tabulate python-terminaltables")
+		install = os.system("apt-get update && apt-get install -y nmap hping3 ruby-dev git libpcap-dev libgmp3-dev python-tabulate python3-terminaltables")
 
 		install1 = os.system("""cd tools/bettercap/ && gem build bettercap.* && sudo gem install xettercap-* && rm xettercap-* && cd ../../ && mkdir -p /opt/xerosploit && cp -R tools/ /opt/xerosploit/ && cp xerosploit.py /opt/xerosploit/xerosploit.py && cp banner.py /opt/xerosploit/banner.py && cp run.sh /usr/bin/xerosploit && chmod +x /usr/bin/xerosploit && tput setaf 34; echo "Xerosploit has been sucessfuly instaled. Execute 'xerosploit' in your terminal." """)
 		


### PR DESCRIPTION
It's still this for me.
I installed the original Lionsec's version this happened.
Then I installed FazalMahmood's fork and this happened again.
Any fixes?

```
Traceback (most recent call last):
  File "/opt/xerosploit/xerosploit.py", line 26, in <module>
    from terminaltables import DoubleTable
ImportError: No module named terminaltables
```